### PR TITLE
Lock ancient Guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,8 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <!-- XXX: don't use dep.guava.version since end users might override it, and newer versions aren't compatible with this ancient version -->
+            <version>16.0.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
If a project (jdbi) uses this plugin, and sets `-Ddep.guava.version=` intending to override
the jdbi version, it also upgrades this plugin's dependency. This introduces incompatible changes since
Guava removes methods (Objects.firstNonNull) leading to

```
Error:  Failed to execute goal org.basepom.maven:property-helper-maven-plugin:2.0:get (basepom.default) on project jdbi3-policy: Execution basepom.default of goal org.basepom.maven:property-helper-maven-plugin:2.0:get failed: An
API incompatibility was encountered while executing org.basepom.maven:property-helper-maven-plugin:2.0:get: java.lang.NoSuchMethodError: 'java.lang.Object com.google.common.base.Objects.firstNonNull(java.lang.Object,
java.lang.Object)'
```